### PR TITLE
CRITICAL: Add missing param to call.

### DIFF
--- a/src-java/FineCollectionService/src/main/java/dapr/fines/vehicle/DefaultVehicleRegistrationClient.java
+++ b/src-java/FineCollectionService/src/main/java/dapr/fines/vehicle/DefaultVehicleRegistrationClient.java
@@ -17,6 +17,6 @@ public class DefaultVehicleRegistrationClient implements VehicleRegistrationClie
     @Override
     public VehicleInfo getVehicleInfo(final String licenseNumber) {
         var params = Map.of("licenseNumber", licenseNumber);
-        return restTemplate.getForObject(vehicleInformationAddress, VehicleInfo.class);
+        return restTemplate.getForObject(vehicleInformationAddress, VehicleInfo.class, params);
     }
 }


### PR DESCRIPTION
The params were not added to the call, leading to a failure when you execute the getVehicleInfo()