### PR TITLE
Remove unused property

### DIFF
--- a/src-java/FineCollectionService/src/main/resources/application.yml
+++ b/src-java/FineCollectionService/src/main/resources/application.yml
@@ -11,6 +11,4 @@ server:
 finefines:
   license-key: HX783-5PN1G-CRJ4A-K2L7V
 
-fine-collection.address: http://localhost:6001/collectfine
-
 vehicle-information.address: http://localhost:6002/vehicleinfo/{licenseNumber}


### PR DESCRIPTION
The FineCollectionService does not need a property towards it's own endpoint. This seems to be a CopyPasta from the TrafficControlService.